### PR TITLE
Chore: Change the format of the file paths output to the command line

### DIFF
--- a/index.js
+++ b/index.js
@@ -48,13 +48,16 @@ forStrictNullCheckEligibleFiles(repoRoot, () => { }, { includeTests }).then(asyn
     if (sort) {
         out = out.sort((a, b) => b[1] - a[1]);
     }
+    
     for (const pair of out) {
-        console.log(toFormattedFilePath(pair[0]) + (printDependedOnCount ? ` — Depended on by **${pair[1]}** files` : ''));
+        // console.log(toFormattedFilePath(pair[0]) + (printDependedOnCount ? ` — Depended on by **${pair[1]}** files` : ''));
+        console.log(toFormattedFilePath(pair[0]));
     }
 });
 
 
 function toFormattedFilePath(file) {
     // return `"./${path.relative(srcRoot, file)}",`;
-    return `- [ ] \`"./${path.relative(srcRoot, file)}"\``;
+    const relativePath = path.relative(srcRoot, file).replace(/\\/g, '/');
+    return `"./src/${relativePath}",`;
 }


### PR DESCRIPTION
This makes it easier to copy file paths directly into tsconfig.strictNullChecks.json.

- Remove the '- [ ]' prefix
- Remove '`' chars from output
- add 'src/' to the relative path to match the addition of '/src' to the search path earlier in the code
- Add commas at the end of lines for json formatting
- Remove the suffix with the dependency count (I only saw the dependency count ever be 0)